### PR TITLE
Feature/authenticator credentials

### DIFF
--- a/Fellowmind.OData.Client.Authentication.AzureIdentity/AzureIdentityAuthenticator.cs
+++ b/Fellowmind.OData.Client.Authentication.AzureIdentity/AzureIdentityAuthenticator.cs
@@ -28,8 +28,8 @@ namespace Fellowmind.OData.Client.Authentication.AzureIdentity
             }
 
             _tokenCredential = new ChainedTokenCredential(
-                new ManagedIdentityCredential(string.IsNullOrEmpty(settings.ManagedIdentityId) ? null : settings.ManagedIdentityId),
                 new EnvironmentCredential(),
+                new ManagedIdentityCredential(string.IsNullOrEmpty(settings.ManagedIdentityId) ? null : settings.ManagedIdentityId),
                 new DefaultAzureCredential()
                 );
             

--- a/Fellowmind.OData.Client.Authentication.AzureIdentity/Fellowmind.OData.Client.Authentication.AzureIdentity.csproj
+++ b/Fellowmind.OData.Client.Authentication.AzureIdentity/Fellowmind.OData.Client.Authentication.AzureIdentity.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.2.3</Version>
+    <Version>4.2.3-preview</Version>
     <Authors>Juho Vainio</Authors>
     <Company>Fellowmind Oy Ab</Company>
     <Product>Fellowmind.OData.Client</Product>

--- a/Fellowmind.OData.Client.Authentication.AzureIdentity/Fellowmind.OData.Client.Authentication.AzureIdentity.csproj
+++ b/Fellowmind.OData.Client.Authentication.AzureIdentity/Fellowmind.OData.Client.Authentication.AzureIdentity.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.2.2</Version>
+    <Version>4.2.3</Version>
     <Authors>Juho Vainio</Authors>
     <Company>Fellowmind Oy Ab</Company>
     <Product>Fellowmind.OData.Client</Product>


### PR DESCRIPTION
Change order of azure creditials so that environment credential is first. This is to prevent slow token retrieve when running the authenticator locally. Set library version to preview